### PR TITLE
Fix command-line arguments & allow using env vars and wildcard IP addresses for server

### DIFF
--- a/src/PanthereTestCase.php
+++ b/src/PanthereTestCase.php
@@ -84,7 +84,7 @@ abstract class PanthereTestCase extends InternalTestCase
         self::$baseUri = null;
     }
 
-    protected static function startWebServer(?string $webServerDir = null): void
+    protected static function startWebServer(?string $webServerDir = null, array $env = [], bool $mergeWithGlobalEnv = true): void
     {
         if (null !== static::$webServerManager) {
             return;
@@ -95,7 +95,12 @@ abstract class PanthereTestCase extends InternalTestCase
             $webServerDir = static::$webServerDir ?? $_ENV['PANTHERE_WEB_SERVER_DIR'] ?? __DIR__.'/../../../../public';
         }
 
-        self::$webServerManager = new WebServerManager($webServerDir, '127.0.0.1', 9000);
+        // $_ENV should already be populated by PHPUnit, but it can be overriden.
+        if ($mergeWithGlobalEnv === true) {
+            $env = array_merge($_ENV, $env);
+        }
+
+        self::$webServerManager = new WebServerManager($webServerDir, '127.0.0.1', 9000, $env);
         self::$webServerManager->start();
 
         self::$baseUri = 'http://127.0.0.1:9000';

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -34,7 +34,7 @@ final class WebServerManager
     /**
      * @throws \RuntimeException
      */
-    public function __construct(string $documentRoot, string $hostname, int $port)
+    public function __construct(string $documentRoot, string $hostname, int $port, array $env = [])
     {
         $this->hostname = $hostname;
         $this->port = $port;
@@ -46,7 +46,7 @@ final class WebServerManager
 
         $commandLine = array_merge([$binary], $finder->findArguments(), ['-dvariables_order=EGPCS', '-S', \sprintf('%s:%d', $this->hostname, $this->port)]);
 
-        $this->process = new Process($commandLine, $documentRoot, null, null, null);
+        $this->process = new Process($commandLine, $documentRoot, $env, null, null);
     }
 
     public function start(): void

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -54,7 +54,7 @@ final class WebServerManager
         $this->checkPortAvailable($this->hostname, $this->port);
         $this->process->start();
 
-        $this->waitUntilReady($this->process, "http://$this->hostname:$this->port", true);
+        $this->waitUntilReady($this->process, "http://$this->hostname:$this->port");
     }
 
     /**

--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -44,7 +44,9 @@ final class WebServerManager
             throw new \RuntimeException('Unable to find the PHP binary.');
         }
 
-        $this->process = new Process([$binary] + $finder->findArguments() + ['-dvariables_order=EGPCS', '-S', \sprintf('%s:%d', $this->hostname, $this->port)], $documentRoot, null, null, null);
+        $commandLine = array_merge([$binary], $finder->findArguments(), ['-dvariables_order=EGPCS', '-S', \sprintf('%s:%d', $this->hostname, $this->port)]);
+
+        $this->process = new Process($commandLine, $documentRoot, null, null, null);
     }
 
     public function start(): void

--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -39,6 +39,13 @@ trait WebServerReadinessProbeTrait
     public function waitUntilReady(Process $process, string $url): void
     {
         $host = parse_url($url, PHP_URL_HOST);
+
+        if ($host === '0.0.0.0') {
+            // When server listens to any host, we can't ping 0.0.0.0 to check if server is ready.
+            // So we listen to local host to be sure it's accessible anyway.
+            $host = '127.0.0.1';
+        }
+
         $port = parse_url($url, PHP_URL_PORT);
 
         $retries = 0;

--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -40,7 +40,7 @@ trait WebServerReadinessProbeTrait
     {
         $host = parse_url($url, PHP_URL_HOST);
 
-        if ($host === '0.0.0.0') {
+        if ('0.0.0.0' === $host) {
             // When server listens to any host, we can't ping 0.0.0.0 to check if server is ready.
             // So we listen to local host to be sure it's accessible anyway.
             $host = '127.0.0.1';
@@ -70,7 +70,7 @@ trait WebServerReadinessProbeTrait
             \usleep(1000);
         } while (Process::STATUS_STARTED !== $status || ++$retries === $maxRetries);
 
-        if (count($socketErrors)) {
+        if (\count($socketErrors)) {
             throw new \RuntimeException(implode("\n", $socketErrors));
         }
 

--- a/src/ProcessManager/WebServerReadinessProbeTrait.php
+++ b/src/ProcessManager/WebServerReadinessProbeTrait.php
@@ -36,23 +36,39 @@ trait WebServerReadinessProbeTrait
         }
     }
 
-    public function waitUntilReady(Process $process, string $url, bool $ignoreErrors = false): void
+    public function waitUntilReady(Process $process, string $url): void
     {
-        $context = \stream_context_create(['http' => [
-            'ignore_errors' => $ignoreErrors,
-            'protocol_version' => '1.1',
-            'header' => ['Connection: close'],
-            'timeout' => 1,
-        ]]);
+        $host = parse_url($url, PHP_URL_HOST);
+        $port = parse_url($url, PHP_URL_PORT);
 
-        while (Process::STATUS_STARTED !== ($status = $process->getStatus()) || false === @\file_get_contents($url, false, $context)) {
+        $retries = 0;
+        $maxRetries = 5;
+
+        $socketErrors = [];
+
+        do {
+            $status = $process->getStatus();
+
+            $socket = fsockopen($host, $port, $errno, $errstr);
+
             if (Process::STATUS_TERMINATED === $status) {
                 throw new \RuntimeException($process->getErrorOutput(), $process->getExitCode());
             }
 
+            if ($errno !== 0) {
+                $socketErrors[] = "#$errno:$errstr";
+            }
+
             // block until the web server is ready
             \usleep(1000);
+        } while (Process::STATUS_STARTED !== $status || ++$retries === $maxRetries);
+
+        if (count($socketErrors)) {
+            throw new \RuntimeException(implode("\n", $socketErrors));
         }
-        \sleep(1);
+
+        if ($socket) {
+            fclose($socket);
+        }
     }
 }


### PR DESCRIPTION
Using PHP 7.2.2 on Windows, testing this code in the WebServerManager:

```php
$commandLine = [$binary] + $finder->findArguments() + ['-dvariables_order=EGPCS', '-S', \sprintf('%s:%d', $this->hostname, $this->port)];

$commandLine2 = array_merge([$binary], $finder->findArguments(), ['-dvariables_order=EGPCS', '-S', \sprintf('%s:%d', $this->hostname, $this->port)]);

dump($commandLine);
dump($commandLine2);
```

And I have this output:

```
array:3 [
  0 => "E:\dev\php72-nts\php.exe"
  1 => "-S"
  2 => "0.0.0.0:12000"
]
array:4 [
  0 => "E:\dev\php72-nts\php.exe"
  1 => "-dvariables_order=EGPCS"
  2 => "-S"
  3 => "0.0.0.0:12000"
]
```

The first one is wrong, so I decided to refactor it with a plain `array_merge()` that will surely be working 👍 

This PR also introduces lots of other changes that allow using env vars and ips like `0.0.0.0` for servers listening to any host. I thought it would be a really nice improvement