### PR TITLE
Delete `$baseUri` on test teardown

### DIFF
--- a/src/PanthereTestCase.php
+++ b/src/PanthereTestCase.php
@@ -80,6 +80,8 @@ abstract class PanthereTestCase extends InternalTestCase
         if (null !== self::$goutteClient) {
             self::$goutteClient = null;
         }
+
+        self::$baseUri = null;
     }
 
     protected static function startWebServer(?string $webServerDir = null): void


### PR DESCRIPTION
Then $baseUri becomes unusable after class teardown, to avoid potential reuse