### PR TITLE
Make Client::submit signature compatible with BrowserKit 4.1

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -123,8 +123,12 @@ final class Client extends BaseClient implements WebDriver
         return parent::click($link);
     }
 
-    public function submit(Form $form, array $values = [])
+    public function submit(Form $form, array $values = [], $serverParameters = null)
     {
+        if (null !== $serverParameters) {
+            throw new \InvalidArgumentException('Server parameters cannot be set when using WebDriver.');
+        }
+
         if ($form instanceof PanthereForm) {
             $button = $form->getButton();
             null === $button ? $form->getElement()->submit() : $button->click();


### PR DESCRIPTION
Since BrowserKit 4.1 was released, the following error occured :

`Warning: Declaration of Panthere\Client::submit(Symfony\Component\DomCrawler\Form $form, array $values = Array) should be compatible with Symfony\Component\BrowserKit\Client::submit(Symfony\Component\DomCrawler\Form $form, array $values = Array, $serverParameters = Array)`

