### PR TITLE
Prevent installing Browser Kit 4.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "symfony/browser-kit": "^4.0",
     "symfony/process": "^4.0"
   },
+  "conflict": {
+    "symfony/browser-kit": "4.1.0"
+  },
   "autoload": {
     "psr-4": { "Panthere\\": "src/" }
   },


### PR DESCRIPTION
Because of symfony/symfony#27485.