### PR TITLE
Explicitly add document root to PHP's web server command line

### DIFF
--- a/src/ProcessManager/WebServerManager.php
+++ b/src/ProcessManager/WebServerManager.php
@@ -45,7 +45,17 @@ final class WebServerManager
         }
 
         $this->process = new Process(
-            \array_merge([$binary], $finder->findArguments(), ['-dvariables_order=EGPCS', '-S', \sprintf('%s:%d', $this->hostname, $this->port)]),
+            \array_merge(
+                [$binary],
+                $finder->findArguments(),
+                [
+                    '-dvariables_order=EGPCS',
+                    '-S',
+                    \sprintf('%s:%d', $this->hostname, $this->port),
+                    '-t',
+                    $documentRoot,
+                ]
+            ),
             $documentRoot,
             null,
             null,


### PR DESCRIPTION
Else, on Windows, web-server is not created properly (possibly because working directory is not injected in the cmd wrapper, but not sure).

Here we are certain that the document root is correct all the time